### PR TITLE
handle disconnect

### DIFF
--- a/UE/Application/Ports/BtsPort.cpp
+++ b/UE/Application/Ports/BtsPort.cpp
@@ -68,7 +68,6 @@ void BtsPort::handleMessage(BinaryMessage msg)
     }
 }
 
-
 void BtsPort::sendAttachRequest(common::BtsId btsId)
 {
     logger.logDebug("sendAttachRequest: ", btsId);
@@ -77,8 +76,6 @@ void BtsPort::sendAttachRequest(common::BtsId btsId)
                                 common::PhoneNumber{}};
     msg.writeBtsId(btsId);
     transport.sendMessage(msg.getMessage());
-
-
 }
 
 }

--- a/UE/Application/States/ConnectedState.cpp
+++ b/UE/Application/States/ConnectedState.cpp
@@ -1,4 +1,5 @@
 #include "ConnectedState.hpp"
+#include "NotConnectedState.hpp"
 
 namespace ue
 {
@@ -7,6 +8,11 @@ ConnectedState::ConnectedState(Context &context)
     : BaseState(context, "ConnectedState")
 {
     context.user.showConnected();
+}
+
+void ConnectedState::handleDisconnected(){
+    logger.logInfo("disconnected");
+    context.setState<NotConnectedState>();
 }
 
 }

--- a/UE/Application/States/ConnectedState.hpp
+++ b/UE/Application/States/ConnectedState.hpp
@@ -9,6 +9,7 @@ class ConnectedState : public BaseState
 {
 public:
     ConnectedState(Context& context);
+    void handleDisconnected() override;
 };
 
 }

--- a/UE/Application/States/ConnectingState.cpp
+++ b/UE/Application/States/ConnectingState.cpp
@@ -32,4 +32,10 @@ void ConnectingState::handleAttachAccept()
     context.setState<ConnectedState>();
 }
 
+void ConnectingState::handleDisconnected()
+{
+    context.logger.logInfo("disconnecting");
+    context.setState<NotConnectedState>();
+}
+
 }

--- a/UE/Application/States/ConnectingState.hpp
+++ b/UE/Application/States/ConnectingState.hpp
@@ -12,6 +12,7 @@ public:
     void handleAttachReject() override;
     void handleTimeout() override;
     void handleAttachAccept() override;
+    void handleDisconnected() override;
 };
 
 }

--- a/UE/Tests/Application/ApplicationTestSuite.cpp
+++ b/UE/Tests/Application/ApplicationTestSuite.cpp
@@ -70,6 +70,12 @@ TEST_F(ApplicationConnectingTestSuite, shallShowNotConnectedOnTimeout)
     objectUnderTest.handleTimeout();
 }
 
+TEST_F(ApplicationConnectingTestSuite, shallShowNotConnectedOnDisconnect)
+{
+    EXPECT_CALL(userPortMock, showNotConnected());
+    objectUnderTest.handleDisconnected();
+}
+
 struct ApplicationConnectedTestSuite : ApplicationConnectingTestSuite
 {
     ApplicationConnectedTestSuite()
@@ -85,4 +91,8 @@ TEST_F(ApplicationConnectedTestSuite, shallShowConnectedOnAttachAccept)
   // Implemented in constructor of test suite
 }
 
+TEST_F(ApplicationConnectedTestSuite, shallShowNotConnectedOnDisconect){
+    EXPECT_CALL(userPortMock, showNotConnected());
+    objectUnderTest.handleDisconnected();
+}
 }

--- a/UE/Tests/Application/Mocks/IBtsPortMock.cpp
+++ b/UE/Tests/Application/Mocks/IBtsPortMock.cpp
@@ -7,6 +7,4 @@ IBtsEventsHandlerMock::~IBtsEventsHandlerMock() = default;
 
 IBtsPortMock::IBtsPortMock() = default;
 IBtsPortMock::~IBtsPortMock() = default;
-
-
 }


### PR DESCRIPTION
Changing the phone status to not connected during disconnect and reattach to BTS when it is possible.